### PR TITLE
fix key mistake

### DIFF
--- a/test_docker/visualize.py
+++ b/test_docker/visualize.py
@@ -29,7 +29,7 @@ else:
     noisepr = None
 
 fig, axs = plt.subplots(1, cols)
-fig.suptitle('score: %.3f' % result['score_sigmoid'])
+fig.suptitle('score: %.3f' % result['score'])
 
 for ax in axs:
     ax.axis('off')


### PR DESCRIPTION
In your code `visualize.py` has a key mistake ,it is `score`, not `score_sigmoid`
https://github.com/grip-unina/TruFor/blob/0f7ccfdc37190ee3f343974bdff37a8cbb2adf31/test_docker/visualize.py#L32